### PR TITLE
(TUR-12194) Updating eigen to 3.4

### DIFF
--- a/libfive/src/eval/eval_array.cpp
+++ b/libfive/src/eval/eval_array.cpp
@@ -236,10 +236,10 @@ void ArrayEvaluator::operator()(Opcode::Opcode op, Clause::Id id,
             out = a * b;
             break;
         case Opcode::OP_MIN:
-            out = a.cwiseMin(b);
+            out = a.template cwiseMin<Eigen::NaNPropagationOptions::PropagateNumbers>(b);
             break;
         case Opcode::OP_MAX:
-            out = a.cwiseMax(b);
+            out = a.template cwiseMax<Eigen::NaNPropagationOptions::PropagateNumbers>(b);
             break;
         case Opcode::OP_SUB:
             out = a - b;

--- a/libfive/src/render/discrete/voxels.cpp
+++ b/libfive/src/render/discrete/voxels.cpp
@@ -23,7 +23,7 @@ Voxels::Voxels(const Eigen::Vector3f& lower, const Eigen::Vector3f& upper,
 Voxels::Voxels(const Eigen::Vector3f& _lower, const Eigen::Vector3f& _upper,
                const Eigen::Vector3f& res)
 {
-    Eigen::Array3i size = (res.array() * (_upper - _lower).array()).ceil().max(1).cast<int>();
+    Eigen::Array3i size = (res.array() * (_upper - _lower).array()).ceil().cwiseMax(1).cast<int>();
 
     // Figure out much should be added to each axis, masking out
     // the case where resolution is zero


### PR DESCRIPTION
This PR updates 3 lines in libfive to make them compatible with Eigen version 3.4. Changes are as follows:

1. NaN propagation in 3.4 doesn't prioritize numbers by default. Rather it has to be specified.
2. max() -> cwiseMax()