### PR TITLE
TUR-15519: Throw an exception when failing to find an installed oracle serialize function.

### DIFF
--- a/libfive/src/oracle/oracle_clause.cpp
+++ b/libfive/src/oracle/oracle_clause.cpp
@@ -1,3 +1,4 @@
+#include <exception>
 #include <iostream>
 #include <cassert>
 
@@ -31,6 +32,7 @@ bool OracleClause::serialize(const std::string& name,
     auto itr = installed().find(name);
     if (itr == installed().end())
     {
+        throw std::invalid_argument(name);
         std::cerr << "OracleClause::serialize: no installed \""
                   << name << "\"\n"
                   << "  You may need to call OracleClause::install."

--- a/libfive/src/oracle/oracle_clause.cpp
+++ b/libfive/src/oracle/oracle_clause.cpp
@@ -32,12 +32,11 @@ bool OracleClause::serialize(const std::string& name,
     auto itr = installed().find(name);
     if (itr == installed().end())
     {
-        throw std::invalid_argument(name);
         std::cerr << "OracleClause::serialize: no installed \""
                   << name << "\"\n"
                   << "  You may need to call OracleClause::install."
                   << std::endl;
-        return false;
+        throw std::invalid_argument(name);
     }
     else
     {

--- a/libfive/src/tree/deserializer.cpp
+++ b/libfive/src/tree/deserializer.cpp
@@ -99,7 +99,7 @@ Archive::Shape Deserializer::deserializeShape(char tag)
                     std::cerr
                         << "Deserializer: failed to deserialize Oracle \""
                         << name << "\"" << std::endl;
-                    return out;
+                    throw std::invalid_argument(name);
                 }
                 trees.insert({next, Tree(std::move(o))});
             }


### PR DESCRIPTION
TUR-155519:
Throw an exception when tree serialization or deserialization fails due to a missing oracle serialization function.
This allows turbo to raise errors in the Export Implicit Body and Import Implicit Body blocks.

Paired with [turbo PR 10446](https://github.com/nTopology/turbo/pull/10446).  (Now [PR 10485](https://github.com/nTopology/turbo/pull/10485)).