### PR TITLE
TUR-16216: Protect against duplicate includes.

### DIFF
--- a/libfive/include/libfive/tree/deserializer.hpp
+++ b/libfive/include/libfive/tree/deserializer.hpp
@@ -7,6 +7,9 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this file,
 You can obtain one at http://mozilla.org/MPL/2.0/.
 */
+
+#pragma once
+
 #include <iostream>
 #include <map>
 

--- a/libfive/include/libfive/tree/serializer.hpp
+++ b/libfive/include/libfive/tree/serializer.hpp
@@ -7,6 +7,8 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this file,
 You can obtain one at http://mozilla.org/MPL/2.0/.
 */
+#pragma once
+
 #include <iostream>
 #include <map>
 


### PR DESCRIPTION
Add pragma once directives to de/'serializer.
Required for [Turbo PR 10649](https://github.com/nTopology/turbo/pull/10649).